### PR TITLE
Fix for HEAD requests with Content-Length

### DIFF
--- a/deproxy.py
+++ b/deproxy.py
@@ -378,8 +378,10 @@ class MessageChain:
                  self.orphaned_handlings))
 
 
-def read_body_from_stream(stream, headers):
-    if ('Transfer-Encoding' in headers and
+def read_body_from_stream(stream, headers, method):
+    if method == "HEAD":  # no body
+        body = None
+    elif ('Transfer-Encoding' in headers and
             headers['Transfer-Encoding'] not in ['identity', 'chunked']):
         # 2
         logger.debug('NotImplementedError - Transfer-Encoding not in "identity", "chunked"')
@@ -604,7 +606,7 @@ class Deproxy:
             logger.debug('  %s: %s', k, v)
 
         logger.debug('Reading body')
-        body = read_body_from_stream(rfile, response_headers)
+        body = read_body_from_stream(rfile, response_headers, request.method)
 
         logger.debug('Creating Response object')
         response = Response(code, message, response_headers, body)
@@ -1071,7 +1073,7 @@ class DeproxyEndpoint:
             persistent_connection = True
 
         logger.debug('reading body')
-        body = read_body_from_stream(rfile, headers)
+        body = read_body_from_stream(rfile, headers, method)
 
         logger.debug('returning')
         return (Request(method, path, headers, body), persistent_connection)


### PR DESCRIPTION
HTTP response to HEAD request might contain `Content-Length` header, even though it doesn't have response body. Without this fix `deproxy` hangs trying to HTTP response body which isn't there.

Don't read response for HEAD requests, even if they contain `Content-Length`.
